### PR TITLE
Add in support for memory and timeout

### DIFF
--- a/src/main/scala/com/gilt/aws/lambda/AwsLambda.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsLambda.scala
@@ -38,7 +38,10 @@ private[lambda] object AwsLambda {
                    functionName: LambdaName,
                    handlerName: HandlerName,
                    roleName: RoleARN,
-                   s3BucketId: S3BucketId): Result[CreateFunctionResult] = {
+                   s3BucketId: S3BucketId,
+                   timeout:  Option[Timeout],
+                   memory: Option[Memory]
+                    ): Result[CreateFunctionResult] = {
     try {
       val client = new AWSLambdaClient(AwsCredentials.provider)
       client.setRegion(RegionUtils.getRegion(region.value))
@@ -49,6 +52,8 @@ private[lambda] object AwsLambda {
         r.setHandler(handlerName.value)
         r.setRole(roleName.value)
         r.setRuntime(com.amazonaws.services.lambda.model.Runtime.Java8)
+        if(timeout.isDefined) r.setTimeout(timeout.get.value)
+        if(memory.isDefined)  r.setMemorySize(memory.get.value)
 
         val functionCode = {
           val c = new FunctionCode

--- a/src/main/scala/com/gilt/aws/lambda/DomainModels.scala
+++ b/src/main/scala/com/gilt/aws/lambda/DomainModels.scala
@@ -11,6 +11,14 @@ case class LambdaName(value: String)
 case class LambdaARN(value: String)
 case class HandlerName(value: String)
 case class RoleARN(value: String)
+case class Timeout(value: Int) {
+  require(value > 0 && value <= 300, "Lambda timeout must be between 1 and 300 seconds")
+}
+case class Memory(value: Int) {
+  require(value >= 128 && value <= 1536, "Lambda memory must be between 128 and 1536 MBs")
+  require(value % 64 == 0)
+}
+
 
 object EnvironmentVariables {
   val region = "AWS_REGION"
@@ -18,4 +26,6 @@ object EnvironmentVariables {
   val lambdaName = "AWS_LAMBDA_NAME"
   val handlerName = "AWS_LAMBDA_HANDLER_NAME"
   val roleArn = "AWS_LAMBDA_IAM_ROLE_ARN"
+  val timeout = "AWS_LAMBDA_TIMEOUT"
+  val memory = "AWS_LAMBDA_MEMORY"
 }


### PR DESCRIPTION
This PR adds in support for specifying a run timeout and memory when creating a new Lambda function. Currently if the parameters are not specified it will just use the Amazon defaults rather than prompting a user to enter it manually.