### PR TITLE
Add ability to specify multiple lambda handlers per project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,38 @@ sbt-aws-lambda can be configured using sbt settings, environment variables or by
 | region |  AWS_REGION | The name of the AWS region to connect to. Defaults to `us-east-1` |
 | awsLambdaTimeout |            | The Lambda timeout in seconds (1-300). Defaults to AWS default. |
 | awsLambdaMemory |             | The amount of memory in MB for the Lambda function (128-1536, multiple of 64). Defaults to AWS default. |
+| lambdaHandlers |              | Sequence of Lambda names to handler functions (for multiple lambda methods per project). Overrides `lambdaName` and `handlerName` if present. | 
+
+An example configuration might look like this:
+
+
+```scala
+retrieveManaged := true
+
+enablePlugins(AwsLambdaPlugin)
+
+lambdaHandlers := Seq(
+  "function1"                 -> "com.gilt.example.Lambda::handleRequest1",
+  "function2"                 -> "com.gilt.example.Lambda::handleRequest2",
+  "function3"                 -> "com.gilt.example.OtherLambda::handleRequest3"
+)
+
+// or, instead of the above, for just one function/handler
+//
+// lambdaName := Some("function1")
+//
+// handlerName := Some("com.gilt.example.Lambda::handleRequest1")
+
+s3Bucket := Some("lambda-jars")
+
+awsLambdaMemory := Some(192)
+
+awsLambdaTimeout := Some(30)
+
+roleArn := Some("arn:aws:iam::123456789000:role/lambda_basic_execution")
+
+```
+(note that you will need to use a real ARN for your role rather than copying this one).
 
 
 Publishing new versions of this plugin


### PR DESCRIPTION
By specifying a sequence of pairs from lambda function name to handler
method, in the `lambdaHandlers` setting, you can create or update multiple
lambda functions with a single create or update operation. When used,
`lambdaHandlers` overrides the single lambda handler specified through
the `lambdaName` and `handlerName` settings, but if `lambdaHandlers` is
ignored, the plugin behaves exactly as before, hence retaining backwards
compatibility with existing plugin usages.
