### PR TITLE
Replaced Result with scala.util.Try

### DIFF
--- a/src/main/scala/com/gilt/aws/lambda/AwsIAM.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsIAM.scala
@@ -4,6 +4,8 @@ import com.amazonaws.{AmazonServiceException, AmazonClientException}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient
 import com.amazonaws.services.identitymanagement.model.{CreateRoleRequest, Role}
 
+import scala.util.{Failure, Success, Try}
+
 private[lambda] object AwsIAM {
 
   val BasicLambdaRoleName = "lambda_basic_execution"
@@ -17,7 +19,7 @@ private[lambda] object AwsIAM {
     existingRoles.find(_.getRoleName == BasicLambdaRoleName)
   }
 
-  def createBasicLambdaRole(): Result[RoleARN] = {
+  def createBasicLambdaRole(): Try[RoleARN] = {
     val createRoleRequest = {
       val policyDocument = """{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}"""
       val c = new CreateRoleRequest

--- a/src/main/scala/com/gilt/aws/lambda/AwsLambda.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsLambda.scala
@@ -6,8 +6,10 @@ import com.amazonaws.services.lambda.AWSLambdaClient
 import com.amazonaws.services.lambda.model._
 import sbt._
 
+import scala.util.{Try, Failure, Success}
+
 private[lambda] object AwsLambda {
-  def updateLambda(region: Region, lambdaName: LambdaName, bucketId: S3BucketId, s3Key: S3Key): Result[UpdateFunctionCodeResult] = {
+  def updateLambda(region: Region, lambdaName: LambdaName, bucketId: S3BucketId, s3Key: S3Key): Try[UpdateFunctionCodeResult] = {
     try {
       val client = new AWSLambdaClient(AwsCredentials.provider)
       client.setRegion(RegionUtils.getRegion(region.value))
@@ -41,7 +43,7 @@ private[lambda] object AwsLambda {
                    s3BucketId: S3BucketId,
                    timeout:  Option[Timeout],
                    memory: Option[Memory]
-                    ): Result[CreateFunctionResult] = {
+                    ): Try[CreateFunctionResult] = {
     try {
       val client = new AWSLambdaClient(AwsCredentials.provider)
       client.setRegion(RegionUtils.getRegion(region.value))

--- a/src/main/scala/com/gilt/aws/lambda/AwsLambdaPlugin.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsLambdaPlugin.scala
@@ -2,6 +2,8 @@ package com.gilt.aws.lambda
 
 import sbt._
 
+import scala.util.{Failure, Success}
+
 object AwsLambdaPlugin extends AutoPlugin {
 
   object autoImport {
@@ -168,8 +170,8 @@ object AwsLambdaPlugin extends AutoPlugin {
           AwsS3.createBucket(bucketId) match {
             case Success(createdBucketId) =>
               createdBucketId
-            case f: Failure =>
-              println(s"Failed to create S3 bucket: ${f.exception.getLocalizedMessage}")
+            case Failure(th) =>
+              println(s"Failed to create S3 bucket: ${th.getLocalizedMessage}")
               promptUserForS3BucketId()
           }
         }
@@ -197,8 +199,8 @@ object AwsLambdaPlugin extends AutoPlugin {
           AwsIAM.createBasicLambdaRole() match {
             case Success(createdRole) =>
               createdRole
-            case f: Failure =>
-              println(s"Failed to create role: ${f.exception.getLocalizedMessage}")
+            case Failure(th) =>
+              println(s"Failed to create role: ${th.getLocalizedMessage}")
               promptUserForRoleARN()
           }
         } else readRoleARN()

--- a/src/main/scala/com/gilt/aws/lambda/AwsS3.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsS3.scala
@@ -5,10 +5,12 @@ import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.{Bucket, CannedAccessControlList, PutObjectRequest}
 import sbt._
 
+import scala.util.{Try, Failure, Success}
+
 private[lambda] object AwsS3 {
   private lazy val client = new AmazonS3Client(AwsCredentials.provider)
 
-  def pushJarToS3(jar: File, bucketId: S3BucketId): Result[S3Key] = {
+  def pushJarToS3(jar: File, bucketId: S3BucketId): Try[S3Key] = {
     try{
       val objectRequest = new PutObjectRequest(bucketId.value, jar.getName, jar)
       objectRequest.setCannedAcl(CannedAccessControlList.AuthenticatedRead)
@@ -28,7 +30,7 @@ private[lambda] object AwsS3 {
     client.listBuckets().asScala.find(_.getName == bucketId.value)
   }
 
-  def createBucket(bucketId: S3BucketId): Result[S3BucketId] = {
+  def createBucket(bucketId: S3BucketId): Try[S3BucketId] = {
     try{
       client.createBucket(bucketId.value)
       Success(bucketId)

--- a/src/main/scala/com/gilt/aws/lambda/DomainModels.scala
+++ b/src/main/scala/com/gilt/aws/lambda/DomainModels.scala
@@ -1,9 +1,5 @@
 package com.gilt.aws.lambda
 
-sealed trait Result[+T]
-case class Success[T](result: T) extends Result[T]
-case class Failure(exception: Throwable) extends Result[Nothing]
-
 case class Region(value: String)
 case class S3BucketId(value: String)
 case class S3Key(value: String)


### PR DESCRIPTION
`scala.util.Try` can be used instead of `com.gilt.aws.lambda.Result`.