### PR TITLE
Allow the s3Key (AWS_LAMBDA_S3_KEY) to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sbt-aws-lambda can be configured using sbt settings, environment variables or by
 | sbt setting   |      Environment variable      |  Description |
 |:----------|:-------------:|:------|
 | s3Bucket |  AWS_LAMBDA_BUCKET_ID | The name of an S3 bucket where the lambda code will be stored |
+| s3KeyPrefix | AWS_LAMBDA_S3_KEY_PREFIX | The prefix to the S3 key where the jar will be uploaded |
 | lambdaName |    AWS_LAMBDA_NAME   |   The name to use for this AWS Lambda function. Defaults to the project name |
 | handlerName | AWS_LAMBDA_HANDLER_NAME |    Java class name and method to be executed, e.g. `com.gilt.example.Lambda::myMethod` |
 | roleArn | AWS_LAMBDA_IAM_ROLE_ARN |The [ARN](http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html "AWS ARN documentation") of an [IAM](https://aws.amazon.com/iam/ "AWS IAM documentation") role to use when creating a new Lambda |

--- a/src/main/scala/com/gilt/aws/lambda/AwsS3.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsS3.scala
@@ -10,14 +10,14 @@ import scala.util.{Try, Failure, Success}
 private[lambda] object AwsS3 {
   private lazy val client = new AmazonS3Client(AwsCredentials.provider)
 
-  def pushJarToS3(jar: File, bucketId: S3BucketId): Try[S3Key] = {
+  def pushJarToS3(jar: File, bucketId: S3BucketId, s3KeyPrefix: String): Try[S3Key] = {
     try{
       val objectRequest = new PutObjectRequest(bucketId.value, jar.getName, jar)
       objectRequest.setCannedAcl(CannedAccessControlList.AuthenticatedRead)
 
       client.putObject(objectRequest)
 
-      Success(S3Key(jar.getName))
+      Success(S3Key(s3KeyPrefix + jar.getName))
     } catch {
       case ex @ (_ : AmazonClientException |
                  _ : AmazonServiceException) =>

--- a/src/main/scala/com/gilt/aws/lambda/DomainModels.scala
+++ b/src/main/scala/com/gilt/aws/lambda/DomainModels.scala
@@ -19,6 +19,7 @@ case class Memory(value: Int) {
 object EnvironmentVariables {
   val region = "AWS_REGION"
   val bucketId = "AWS_LAMBDA_BUCKET_ID"
+  val s3KeyPrefix = "AWS_LAMBDA_S3_KEY_PREFIX"
   val lambdaName = "AWS_LAMBDA_NAME"
   val handlerName = "AWS_LAMBDA_HANDLER_NAME"
   val roleArn = "AWS_LAMBDA_IAM_ROLE_ARN"


### PR DESCRIPTION
This case is a bit different than the rest because the fallback value is actually already in sbt's task graph (the jar name).

Also I opted for using the `?` operator on SettingKey instead of defining the key to be Option[String]. Just because I think it's a more pleasant user-experience, but it doesn't have to stay this way. I can either revert to Option, leave it as is, or change all of them to not be option (massive breaking change, but would make all the keys consistent). I'm happy to do either, just presenting this way as my preference.