### PR TITLE
Combine createLambda and updateLambda into deployLambda

### DIFF
--- a/src/main/scala/com/gilt/aws/lambda/AwsLambda.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsLambda.scala
@@ -9,70 +9,73 @@ import sbt._
 import scala.util.{Try, Failure, Success}
 
 private[lambda] object AwsLambda {
-  def updateLambda(region: Region, lambdaName: LambdaName, bucketId: S3BucketId, s3Key: S3Key): Try[UpdateFunctionCodeResult] = {
-    try {
-      val client = new AWSLambdaClient(AwsCredentials.provider)
-      client.setRegion(RegionUtils.getRegion(region.value))
 
-      val request = {
-        val r = new UpdateFunctionCodeRequest()
-        r.setFunctionName(lambdaName.value)
-        r.setS3Bucket(bucketId.value)
-        r.setS3Key(s3Key.value)
-
-        r
-      }
-
-      val updateResult = client.updateFunctionCode(request)
-
-      println(s"Updated lambda ${updateResult.getFunctionArn}")
-      Success(updateResult)
-    }
-    catch {
-      case ex @ (_ : AmazonClientException |
-                 _ : AmazonServiceException) =>
-        Failure(ex)
-    }
-  }
-
-  def createLambda(region: Region,
+  def deployLambda(region: Region,
                    jar: File,
                    functionName: LambdaName,
                    handlerName: HandlerName,
                    roleName: RoleARN,
                    s3BucketId: S3BucketId,
+                   s3Key: S3Key,
                    timeout:  Option[Timeout],
                    memory: Option[Memory]
-                    ): Try[CreateFunctionResult] = {
+                  ): Try[Either[CreateFunctionResult, UpdateFunctionCodeResult]] = {
     try {
       val client = new AWSLambdaClient(AwsCredentials.provider)
       client.setRegion(RegionUtils.getRegion(region.value))
 
-      val request = {
-        val r = new CreateFunctionRequest()
-        r.setFunctionName(functionName.value)
-        r.setHandler(handlerName.value)
-        r.setRole(roleName.value)
-        r.setRuntime(com.amazonaws.services.lambda.model.Runtime.Java8)
-        if(timeout.isDefined) r.setTimeout(timeout.get.value)
-        if(memory.isDefined)  r.setMemorySize(memory.get.value)
-
-        val functionCode = {
-          val c = new FunctionCode
-          c.setS3Bucket(s3BucketId.value)
-          c.setS3Key(jar.getName)
-          c
-        }
-
-        r.setCode(functionCode)
-
-        r
+      val isNew = try {
+        val getRequest = new GetFunctionRequest
+        getRequest.setFunctionName(functionName.value)
+        client.getFunction(getRequest)
+        false
+      }
+      catch {
+        case _ : ResourceNotFoundException => true
       }
 
-      val createResult = client.createFunction(request)
+      if(isNew) {
+        val request = {
+          val r = new CreateFunctionRequest()
+          r.setFunctionName(functionName.value)
+          r.setHandler(handlerName.value)
+          r.setRole(roleName.value)
+          r.setRuntime(com.amazonaws.services.lambda.model.Runtime.Java8)
+          if(timeout.isDefined) r.setTimeout(timeout.get.value)
+          if(memory.isDefined)  r.setMemorySize(memory.get.value)
 
-      println(s"Created Lambda: ${createResult.getFunctionArn}")
-      Success(createResult)
+          val functionCode = {
+            val c = new FunctionCode
+            c.setS3Bucket(s3BucketId.value)
+            c.setS3Key(jar.getName)
+            c
+          }
+
+          r.setCode(functionCode)
+
+          r
+        }
+
+        val createResult = client.createFunction(request)
+
+        println(s"Created Lambda: ${createResult.getFunctionArn}")
+        Success(Left(createResult))
+
+      } else {
+        val request = {
+          val r = new UpdateFunctionCodeRequest()
+          r.setFunctionName(functionName.value)
+          r.setS3Bucket(s3BucketId.value)
+          r.setS3Key(s3Key.value)
+
+          r
+        }
+
+        val updateResult = client.updateFunctionCode(request)
+
+        println(s"Updated lambda ${updateResult.getFunctionArn}")
+        Success(Right(updateResult))
+      }
     }
     catch {
       case ex @ (_ : AmazonClientException |

--- a/src/main/scala/com/gilt/aws/lambda/AwsLambdaPlugin.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsLambdaPlugin.scala
@@ -2,13 +2,14 @@ package com.gilt.aws.lambda
 
 import sbt._
 
-import scala.util.{Failure, Success}
+import scala.util.{Either, Failure, Success}
 
 object AwsLambdaPlugin extends AutoPlugin {
 
   object autoImport {
     val createLambda = taskKey[Map[String, LambdaARN]]("Create a new AWS Lambda function from the current project")
-    val updateLambda = taskKey[Map[String, LambdaARN]]("Package and deploy the current project to an existing AWS Lambda")
+    val updateLambda = taskKey[Map[String, LambdaARN]]("[Deprecated: use deployLambda] Package and deploy the current project to an existing AWS Lambda")
+    val deployLambda = taskKey[Map[String, LambdaARN]]("Package and deploy the current project to AWS Lambda")
 
     val s3Bucket = settingKey[Option[String]]("ID of the S3 bucket where the jar will be uploaded")
     val s3KeyPrefix = settingKey[String]("The prefix to the S3 key where the jar will be uploaded")
@@ -26,16 +27,15 @@ object AwsLambdaPlugin extends AutoPlugin {
   override def requires = sbtassembly.AssemblyPlugin
 
   override lazy val projectSettings = Seq(
-    updateLambda := doUpdateLambda(
-      region = region.value,
-      jar = sbtassembly.AssemblyKeys.assembly.value,
-      s3Bucket = s3Bucket.value,
-      s3KeyPrefix = s3KeyPrefix.?.value,
-      lambdaName = lambdaName.value,
-      handlerName = handlerName.value,
-      lambdaHandlers = lambdaHandlers.value
-    ),
-    createLambda := doCreateLambda(
+    updateLambda := {
+      println("Deprecated: Use deployLambda.")
+      deployLambda.value
+    },
+    createLambda := {
+      println("Deprecated: Use deployLambda.")
+      deployLambda.value
+    },
+    deployLambda := doDeployLambda(
       region = region.value,
       jar = sbtassembly.AssemblyKeys.assembly.value,
       s3Bucket = s3Bucket.value,
@@ -57,43 +57,26 @@ object AwsLambdaPlugin extends AutoPlugin {
     awsLambdaTimeout := None
   )
 
-  private def doUpdateLambda(region: Option[String], jar: File, s3Bucket: Option[String], s3KeyPrefix: Option[String], lambdaName: Option[String], 
-      handlerName: Option[String], lambdaHandlers: Seq[(String, String)]): Map[String, LambdaARN] = {
+  private def doDeployLambda(region: Option[String], jar: File, s3Bucket: Option[String], s3KeyPrefix: Option[String], lambdaName: Option[String],
+                             handlerName: Option[String], lambdaHandlers: Seq[(String, String)], roleArn: Option[String], timeout: Option[Int], memory: Option[Int]): Map[String, LambdaARN] = {
     val resolvedRegion = resolveRegion(region)
     val resolvedBucketId = resolveBucketId(s3Bucket)
     val resolvedS3KeyPrefix = resolveS3KeyPrefix(s3KeyPrefix)
     val resolvedLambdaHandlers = resolveLambdaHandlers(lambdaName, handlerName, lambdaHandlers)
 
-    AwsS3.pushJarToS3(jar, resolvedBucketId, resolvedS3KeyPrefix) match {
-      case Success(s3Key) => (for (resolvedLambdaName <- resolvedLambdaHandlers.keys) yield {
-        AwsLambda.updateLambda(resolvedRegion, resolvedLambdaName, resolvedBucketId, s3Key) match {
-          case Success(updateFunctionCodeResult) =>
-            resolvedLambdaName.value -> LambdaARN(updateFunctionCodeResult.getFunctionArn)
-          case Failure(exception) =>
-            sys.error(s"Error updating lambda: ${exception.getLocalizedMessage}\n${exception.getStackTraceString}")
-        }
-      }).toMap
-      case Failure(exception) =>
-        sys.error(s"Error uploading jar to S3 lambda: ${exception.getLocalizedMessage}\n${exception.getStackTraceString}")
-    }
-  }
-
-  private def doCreateLambda(region: Option[String], jar: File, s3Bucket: Option[String], s3KeyPrefix: Option[String], lambdaName: Option[String], 
-      handlerName: Option[String], lambdaHandlers: Seq[(String, String)], roleArn: Option[String], timeout: Option[Int], memory: Option[Int]): Map[String, LambdaARN] = {
-    val resolvedRegion = resolveRegion(region)
-    val resolvedLambdaHandlers = resolveLambdaHandlers(lambdaName, handlerName, lambdaHandlers)
     val resolvedRoleName = resolveRoleARN(roleArn)
-    val resolvedBucketId = resolveBucketId(s3Bucket)
-    val resolvedS3KeyPrefix = resolveS3KeyPrefix(s3KeyPrefix)
     val resolvedTimeout = resolveTimeout(timeout)
     val resolvedMemory = resolveMemory(memory)
 
     AwsS3.pushJarToS3(jar, resolvedBucketId, resolvedS3KeyPrefix) match {
       case Success(s3Key) =>
         for ((resolvedLambdaName, resolvedHandlerName) <- resolvedLambdaHandlers) yield {
-          AwsLambda.createLambda(resolvedRegion, jar, resolvedLambdaName, resolvedHandlerName, resolvedRoleName, resolvedBucketId, resolvedTimeout, resolvedMemory) match {
-            case Success(createFunctionCodeResult) =>
+
+          AwsLambda.deployLambda(resolvedRegion, jar, resolvedLambdaName, resolvedHandlerName, resolvedRoleName, resolvedBucketId, s3Key, resolvedTimeout, resolvedMemory) match {
+            case Success(Left(createFunctionCodeResult)) =>
               resolvedLambdaName.value -> LambdaARN(createFunctionCodeResult.getFunctionArn)
+            case Success(Right(updateFunctionCodeResult)) =>
+              resolvedLambdaName.value -> LambdaARN(updateFunctionCodeResult.getFunctionArn)
             case Failure(exception) =>
               sys.error(s"Failed to create lambda function: ${exception.getLocalizedMessage}\n${exception.getStackTraceString}")
           }


### PR DESCRIPTION
Hi,

First of all, thanks a ton for creating this plugin. I'm exploring the AWS lambda and 
this plugin has saved me a lot of time.
The problem was that when I added a new function to lambdaHandlers, and then I ran createLambda task again, it failed because the first function in lambdaHandlers already existed.
I had to comment it out, and re-ran the task. This is quite inconvenient for a new project
that may have new function added frequently. 
I did a quick fix and hopefully this would be useful to others. 

Thanks again for sharing this plugin!
Huss
