### PR TITLE
Change deadLetterArn to be optional

### DIFF
--- a/src/main/scala/com/gilt/aws/lambda/AwsLambda.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsLambda.scala
@@ -73,7 +73,8 @@ private[lambda] object AwsLambda {
         r.setRuntime(com.amazonaws.services.lambda.model.Runtime.Java8)
         if(timeout.isDefined) r.setTimeout(timeout.get.value)
         if(memory.isDefined)  r.setMemorySize(memory.get.value)
-        r.setDeadLetterConfig(new DeadLetterConfig().withTargetArn(deadLetterName.get.value))
+        if(deadLetterName.isDefined)
+          r.setDeadLetterConfig(new DeadLetterConfig().withTargetArn(deadLetterName.get.value))
         r.setCode(functionCode)
 
         r

--- a/src/main/scala/com/gilt/aws/lambda/AwsLambdaPlugin.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsLambdaPlugin.scala
@@ -61,7 +61,8 @@ object AwsLambdaPlugin extends AutoPlugin {
     region := None,
     deployMethod := Some("S3"),
     awsLambdaMemory := None,
-    awsLambdaTimeout := None
+    awsLambdaTimeout := None,
+    deadLetterArn := None
   )
 
   private def doUpdateLambda(deployMethod: Option[String], region: Option[String], jar: File, s3Bucket: Option[String], s3KeyPrefix: Option[String],


### PR DESCRIPTION
This is meant to resolve #34  which asks for deadLetterArn to be an optional setting to avoid breaking projects that do not use it.