### PR TITLE
vpcConfigSubnetIds and vpcConfigSecurityGroupIds haven't default value

### DIFF
--- a/src/main/scala/com/gilt/aws/lambda/AwsLambdaPlugin.scala
+++ b/src/main/scala/com/gilt/aws/lambda/AwsLambdaPlugin.scala
@@ -67,7 +67,9 @@ object AwsLambdaPlugin extends AutoPlugin {
     deployMethod := Some("S3"),
     awsLambdaMemory := None,
     awsLambdaTimeout := None,
-    deadLetterArn := None
+    deadLetterArn := None,
+    vpcConfigSubnetIds := None,
+    vpcConfigSecurityGroupIds := None
   )
 
   private def doUpdateLambda(deployMethod: Option[String], region: Option[String], jar: File, s3Bucket: Option[String], s3KeyPrefix: Option[String],


### PR DESCRIPTION
if `vpcConfigSubnetIds` or `vpcConfigSecurityGroupIds` not setting, sbt failed.